### PR TITLE
Switched "Apply to Speak" with "Apply to Hack"

### DIFF
--- a/src/components/Manifesto.vue
+++ b/src/components/Manifesto.vue
@@ -4,18 +4,18 @@
     <div class="manifesto__buttons">
       <div class="manifesto__buttons-row">
       <a
-        href="https://cfp.paralelnipolis.cz/ethprague-2022/"
-        target="_blank"
-        class="manifesto__button-link"
-      >
-        <button class="manifesto__button">Apply to speak <span class="manifesto__headless-arrow"/></button>
-      </a>
-      <a
         href="https://cf23uhv4kuq.typeform.com/to/XABwNH5T"
         target="_blank"
         class="manifesto__button-link"
       >
         <button class="manifesto__button">Apply to hack <span class="manifesto__headless-arrow"/></button>
+      </a>
+      <a
+        href="https://cfp.paralelnipolis.cz/ethprague-2022/"
+        target="_blank"
+        class="manifesto__button-link"
+      >
+        <button class="manifesto__button">Apply to speak <span class="manifesto__headless-arrow"/></button>
       </a>
       </div>
 <!--      <div class="manifesto__buttons-row">-->


### PR DESCRIPTION
Prior to change, the first call to action is "Apply to Speak", and this appears "above the fold" on a mobile device:

![image](https://user-images.githubusercontent.com/2212651/162932038-5cf49906-fc33-4b3b-83e0-3775b5195e7f.png)

This proposal is to put "Apply to Hack" as priority, so that it appears "above the fold".